### PR TITLE
 Switch to OkHttpDataSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Download](https://api.bintray.com/packages/saschpe/maven/android-exoplayer2-ext-icy/images/download.svg)](https://bintray.com/saschpe/maven/android-exoplayer2-ext-icy/_latestVersion)
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 [![Build Status](https://travis-ci.org/saschpe/android-exoplayer2-ext-icy.svg?branch=master)](https://travis-ci.org/saschpe/android-exoplayer2-ext-icy)
-<a href="http://www.methodscount.com/?lib=saschpe.android%3Aandroid-exoplayer2-ext-icy%3A1.1.0"><img src="https://img.shields.io/badge/Methods and size-core: 100 | deps: 19640 | 25 KB-e91e63.svg"/></a>
+<a href="http://www.methodscount.com/?lib=saschpe.android%3Aandroid-exoplayer2-ext-icy%3A2.0.0"><img src="https://img.shields.io/badge/Methods and size-core: 100 | deps: 19640 | 25 KB-e91e63.svg"/></a>
 
 The Shoutcast Metadata Protocol extension provides **IcyHttpDataSource** and 
 **IcyHttpDataSourceFactory** which can parse ICY metadata information such as stream name and
@@ -46,7 +46,7 @@ val mediaSource = ExtractorMediaSource.Factory(dataSourceFactory)
 
 # Download
 ```groovy
-implementation 'saschpe.android:exoplayer2-ext-icy:1.1.0'
+implementation 'saschpe.android:exoplayer2-ext-icy:2.0.0'
 ```
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.android.support:design:28.0.0'
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.8.4'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.26.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:0.26.1'

--- a/example/src/main/java/com/example/exoplayer2/ext/icy/MainActivity.kt
+++ b/example/src/main/java/com/example/exoplayer2/ext/icy/MainActivity.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.experimental.CoroutineStart
 import kotlinx.coroutines.experimental.Dispatchers
 import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.async
+import okhttp3.OkHttpClient
 import saschpe.exoplayer2.ext.icy.IcyHttpDataSourceFactory
 
 /**
@@ -67,7 +68,9 @@ class MainActivity : AppCompatActivity() {
 
             // Custom HTTP data source factory which requests Icy metadata and parses it if
             // the stream server supports it
-            val icyHttpDataSourceFactory = IcyHttpDataSourceFactory.Builder(userAgent)
+            val client = OkHttpClient.Builder().build()
+            val icyHttpDataSourceFactory = IcyHttpDataSourceFactory.Builder(client)
+                    .setUserAgent(userAgent)
                     .setIcyHeadersListener { icyHeaders ->
                         Log.d(TAG, "onIcyMetaData: icyHeaders=$icyHeaders")
                     }

--- a/exoplayer2-ext-icy/build.gradle
+++ b/exoplayer2-ext-icy/build.gradle
@@ -36,7 +36,7 @@ android {
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 28
-        versionName '1.1.0'
+        versionName '2.0.0'
     }
 
     buildTypes {

--- a/exoplayer2-ext-icy/build.gradle
+++ b/exoplayer2-ext-icy/build.gradle
@@ -53,7 +53,8 @@ android {
 
 dependencies {
     // Runtime dependencies
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.8.4'
+    api 'com.google.android.exoplayer:exoplayer-core:2.8.4'
+    api 'com.google.android.exoplayer:extension-okhttp:2.8.4'
 
     // Test dependencies
     testImplementation 'junit:junit:4.12'

--- a/exoplayer2-ext-icy/src/test/java/saschpe/exoplayer2/ext/icy/IcyHttpDataSourceFactoryTest.java
+++ b/exoplayer2-ext-icy/src/test/java/saschpe/exoplayer2/ext/icy/IcyHttpDataSourceFactoryTest.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import okhttp3.OkHttpClient;
 import saschpe.exoplayer2.ext.icy.test.Constants;
 
 import static org.junit.Assert.assertNotNull;
@@ -49,11 +50,10 @@ public final class IcyHttpDataSourceFactoryTest {
     @Test
     public void createDataSourceViaFactoryFromFactoryBuilder() {
         // Arrange
-        IcyHttpDataSourceFactory factory = new IcyHttpDataSourceFactory.Builder(Constants.TEST_USER_AGENT)
+        OkHttpClient client = new OkHttpClient.Builder().build();
+        IcyHttpDataSourceFactory factory = new IcyHttpDataSourceFactory.Builder(client)
+                .setUserAgent(Constants.TEST_USER_AGENT)
                 .setTransferListener(TEST_TRANSFER_LISTENER)
-                .setConnectTimeoutMillis(Constants.TEST_CONNECT_TIMEOUT_MS)
-                .setReadTimeoutMillis(Constants.TEST_READ_TIMEOUT_MS)
-                .setAllowCrossProtocolRedirects(Constants.TEST_ALLOW_CROSS_PROTOCOL_REDIRECTS)
                 .setIcyHeadersListener(TEST_ICY_HEADERS_LISTENER)
                 .setIcyMetadataChangeListener(TEST_ICY_METADATA_LISTENER)
                 .build();

--- a/exoplayer2-ext-icy/src/test/java/saschpe/exoplayer2/ext/icy/IcyHttpDataSourceTest.java
+++ b/exoplayer2-ext-icy/src/test/java/saschpe/exoplayer2/ext/icy/IcyHttpDataSourceTest.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import okhttp3.OkHttpClient;
 import saschpe.exoplayer2.ext.icy.test.Constants;
 
 import static org.junit.Assert.assertNotNull;
@@ -15,10 +16,9 @@ public final class IcyHttpDataSourceTest {
     @Test
     public void createDataSourceFromBuilder() {
         // Arrange, act
-        IcyHttpDataSource source = new IcyHttpDataSource.Builder(Constants.TEST_USER_AGENT)
-                .setConnectTimeoutMillis(Constants.TEST_CONNECT_TIMEOUT_MS)
-                .setReadTimeoutMillis(Constants.TEST_READ_TIMEOUT_MS)
-                .setAllowCrossProtocolRedirects(Constants.TEST_ALLOW_CROSS_PROTOCOL_REDIRECTS)
+        OkHttpClient client = new OkHttpClient.Builder().build();
+        IcyHttpDataSource source = new IcyHttpDataSource.Builder(client)
+                .setUserAgent(Constants.TEST_USER_AGENT)
                 .build();
 
         // Assert

--- a/exoplayer2-ext-icy/src/test/java/saschpe/exoplayer2/ext/icy/test/Constants.java
+++ b/exoplayer2-ext-icy/src/test/java/saschpe/exoplayer2/ext/icy/test/Constants.java
@@ -5,7 +5,4 @@ package saschpe.exoplayer2.ext.icy.test;
  */
 public final class Constants {
     public static final String TEST_USER_AGENT = "test-agent";
-    public static final int TEST_CONNECT_TIMEOUT_MS = 100;
-    public static final int TEST_READ_TIMEOUT_MS = 100;
-    public static final boolean TEST_ALLOW_CROSS_PROTOCOL_REDIRECTS = true;
 }


### PR DESCRIPTION
As requested in ExoPlayer issue 3735 [0]. Changes exoplayer dependencies to 'api' to ensure library users automatically get it.

[0] google/ExoPlayer#3735