### PR TITLE
Update to exoplayer 2.10

### DIFF
--- a/exoplayer2-ext-icy/build.gradle
+++ b/exoplayer2-ext-icy/build.gradle
@@ -58,8 +58,8 @@ android {
 
 dependencies {
     // Runtime dependencies
-    api 'com.google.android.exoplayer:exoplayer-core:2.9.0'
-    api 'com.google.android.exoplayer:extension-okhttp:2.9.0'
+    api 'com.google.android.exoplayer:exoplayer-core:2.10.0'
+    api 'com.google.android.exoplayer:extension-okhttp:2.10.0'
 
     // Test dependencies
     testImplementation 'junit:junit:4.12'

--- a/exoplayer2-ext-icy/src/main/java/saschpe/exoplayer2/ext/icy/IcyHttpDataSource.java
+++ b/exoplayer2-ext-icy/src/main/java/saschpe/exoplayer2/ext/icy/IcyHttpDataSource.java
@@ -118,7 +118,7 @@ public final class IcyHttpDataSource extends OkHttpDataSource {
             } else {
                 remainingStreamDataUntilMetaDataBlock -= bytesRead;
             }
-            //bytesRead = 0;
+            bytesRead = 0;
         }
         return bytesRead;
     }

--- a/exoplayer2-ext-icy/src/main/java/saschpe/exoplayer2/ext/icy/IcyHttpDataSource.java
+++ b/exoplayer2-ext-icy/src/main/java/saschpe/exoplayer2/ext/icy/IcyHttpDataSource.java
@@ -1,7 +1,7 @@
 package saschpe.exoplayer2.ext.icy;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import com.google.android.exoplayer2.ext.okhttp.OkHttpDataSource;
@@ -109,7 +109,7 @@ public final class IcyHttpDataSource extends OkHttpDataSource {
         int bytesRead;
 
         // Only read metadata if the server declared to send it...
-        if (metaDataIntervalInBytes < 0) {
+        if (metaDataIntervalInBytes <= 0) {
             bytesRead = super.read(buffer, offset, readLength);
         } else {
             bytesRead = super.read(buffer, offset, remainingStreamDataUntilMetaDataBlock < readLength ? remainingStreamDataUntilMetaDataBlock : readLength);
@@ -118,6 +118,7 @@ public final class IcyHttpDataSource extends OkHttpDataSource {
             } else {
                 remainingStreamDataUntilMetaDataBlock -= bytesRead;
             }
+            //bytesRead = 0;
         }
         return bytesRead;
     }
@@ -167,6 +168,7 @@ public final class IcyHttpDataSource extends OkHttpDataSource {
             } catch (Exception e) {
                 Log.e(TAG, "parseIcyMetadata: Cannot convert bytes to String");
             }
+            metaDataIntervalInBytes =- bytesRead;
         }
     }
 

--- a/exoplayer2-ext-icy/src/main/java/saschpe/exoplayer2/ext/icy/IcyHttpDataSourceFactory.java
+++ b/exoplayer2-ext-icy/src/main/java/saschpe/exoplayer2/ext/icy/IcyHttpDataSourceFactory.java
@@ -1,7 +1,6 @@
 package saschpe.exoplayer2.ext.icy;
 
-import android.support.annotation.NonNull;
-
+import androidx.annotation.NonNull;
 import com.google.android.exoplayer2.ext.okhttp.OkHttpDataSource;
 import com.google.android.exoplayer2.upstream.HttpDataSource;
 import com.google.android.exoplayer2.util.Predicate;


### PR DESCRIPTION
Hi guys! Here you can find a small fix in order to make _exoplayer2-ext-icy_ work with _exoplayer2 2.10.0_.
There was a some problem in the metadata reading process which caused a failure in the exoplayer data interpretation.
I hope you like it!